### PR TITLE
[Test] 93. Restore IP Addresses

### DIFF
--- a/leetcodePython/Backtracking/bt_93.py
+++ b/leetcodePython/Backtracking/bt_93.py
@@ -46,3 +46,19 @@ class Solution:
 
         backtrack(0)
         return addresses
+
+
+import pytest
+target = Solution()
+
+@pytest.mark.parametrize("digitsStr, expect",
+[
+    ("1234", ["1.2.3.4"]),
+    ("01234", ["0.1.2.34", "0.1.23.4", "0.12.3.4"]),
+    ("255000", ["25.50.0.0", "255.0.0.0"]),
+    ("256000", ["25.60.0.0"]),
+    ("262626260", []),
+    ("26262626", ["26.26.26.26"]),
+])
+def test_restoreIpAddresses(digitsStr, expect):
+    assert target.restoreIpAddresses(digitsStr) == expect


### PR DESCRIPTION
# [93. Restore IP Addresses](https://leetcode.com/problems/restore-ip-addresses/)
A valid IP address consists of exactly four integers separated by single dots. Each integer is between 0 and 255 (inclusive) and cannot have leading zeros.

* For example, "0.1.2.201" and "192.168.1.1" are valid IP addresses, but "0.011.255.245", "192.168.1.312" and "192.168@1.1" are invalid IP addresses.
Given a string s containing only digits, return all possible valid IP addresses that can be formed by inserting dots into s. You are not allowed to reorder or remove any digits in s. You may return the valid IP addresses in any order.
```Python3
from typing import List

class Solution:
    def restoreIpAddresses(self, s: str) -> List[str]:
        return []
```

# Test Case

# Pattern