### PR TITLE
[Test] Maximum Non-adjacent Sum 

### DIFF
--- a/leetcodePython/Meta/NonAdjacentMaxSum.py
+++ b/leetcodePython/Meta/NonAdjacentMaxSum.py
@@ -18,3 +18,15 @@ class Solution:
 
 
 
+import pytest
+
+target = Solution()
+
+@pytest.mark.parametrize("nums, expect",
+[
+    ([1, 3, 4, 3], 6),
+    ([-10, 3, -2], -12),
+    ([1, 5, 4, 1, 3], 8),
+])
+def test_maxNonAdjacentSum(nums, expect):
+    assert target.maxNonAdjacentSum(nums) == expect


### PR DESCRIPTION
# Maximum Non-adjacent Sum
* Given a numeric array with number of elements not less than 3. 
* Take any two non-adjacent numbers. Get the sum of them.
* Get the maximum sum from all the options.

```Python3
from typing import List

class Solution:
    def maxNonAdjacentSum(self, nums: List[int]) -> int:
        return -1
```

Requirement:
Optimize runtime and memory as much as possible.

# Test Case