### PR TITLE
[Test] 708. Insert into a Sorted Circular Linked List

### DIFF
--- a/leetcodePython/LinkedList/linkedlist_708.py
+++ b/leetcodePython/LinkedList/linkedlist_708.py
@@ -30,3 +30,19 @@ class Solution:
 
 
 
+from linkedlist import CircularList
+
+import pytest
+target = Solution()
+
+@pytest.mark.parametrize("dataList, insertValue, expect",
+[
+    ([3, 4, 2], 1, [3, 4, 1, 2]),
+    ([2, 3], 1, [2, 3, 1]),
+    ([5, 5], 1, [5, 5, 1]),
+    ([5, 5], 6, [5, 5, 6])
+])
+def test_insert(dataList, insertValue, expect):
+    node = CircularList.buildCircular(dataList)
+    node = target.insert(node, insertValue)
+    assert CircularList.GetList(node) == expect


### PR DESCRIPTION
# [708. Insert into a Sorted Circular Linked List](https://leetcode.com/problems/insert-into-a-sorted-circular-linked-list/)
Given a Circular Linked List node, which is sorted in non-descending order, write a function to insert a value insertVal into the list such that it remains a sorted circular list. The given node can be a reference to any single node in the list and may not necessarily be the smallest value in the circular list.

If there are multiple suitable places for insertion, you may choose any place to insert the new value. After the insertion, the circular list should remain sorted.

If the list is empty (i.e., the given node is null), you should create a new single circular list and return the reference to that single node. Otherwise, you should return the originally given node.
```Python3
from typing import Optional
from linkedlist import Node


class Solution:
    def insert(self, head: Optional[Node], insertVal: int) -> Node:
        return Node()
```
# Test Case