### PR TITLE
[Test] 947. Most Stones Removed with Same Row or Column

### DIFF
--- a/leetcodePython/Graph/graph_947.py
+++ b/leetcodePython/Graph/graph_947.py
@@ -15,3 +15,17 @@ class Solution:
 
 
 
+
+import pytest
+target = Solution()
+
+@pytest.mark.parametrize("stones, expect",
+[
+    ([[1, 2], [1, 3]], 1),
+    ([[1,2], [1,3],[2,2]], 2),
+    ([[1, 2], [1, 3], [2, 2], [3, 1]], 2),
+    ([[1, 2], [1, 3], [2, 2], [3, 1], [3, 4]], 3),
+    ([[1, 2], [1, 3], [2, 2], [3, 1], [3, 4], [3, 2]], 5),
+])
+def test_removeStones(stones, expect):
+    assert target.removeStones(stones) == expect


### PR DESCRIPTION
# [947. Most Stones Removed with Same Row or Column](https://leetcode.com/problems/most-stones-removed-with-same-row-or-column/)
On a 2D plane, we place `n` stones at some integer coordinate points. Each coordinate point may have at most one stone.

A stone can be removed if it shares either the same row or the same column as another stone that has not been removed.

Given an array `stones` of length `n` where `stones[i] = [xi, yi]` represents the location of the `ith` stone, return the largest possible number of stones that can be removed.

```Python3
from typing import List

class Solution:
    def removeStones(self, stones: List[List[int]]) -> int:
        return -1
```

# Test Case