### PR TITLE
[Test] 1574. Shortest Subarray to be Removed to Make Array Sorted

### DIFF
--- a/leetcodePython/TwoPointers/twopointers_1574.py
+++ b/leetcodePython/TwoPointers/twopointers_1574.py
@@ -24,3 +24,17 @@ class Solution:
 
 
 
+
+import pytest
+target = Solution()
+
+@pytest.mark.parametrize("arr, expect",
+[
+    ([1, 2], 0), ([1, 1], 0),
+    ([2, 1], 1),
+    ([1, 2, 1, 1], 1),
+    ([1, 2, 3, 2, 2, 1, 1, 1], 4),
+    ([1, 2, 3, 2, 2, 1, 2, 3], 4)
+])
+def test_findLengthOfShortestSubarray(arr, expect):
+    assert target.findLengthOfShortestSubarray(arr) == expect


### PR DESCRIPTION
# [1574. Shortest Subarray to be Removed to Make Array Sorted](https://leetcode.com/problems/shortest-subarray-to-be-removed-to-make-array-sorted/)
Given an integer array `arr`, remove a subarray (can be empty) from `arr` such that the remaining elements in `arr` are non-decreasing.

Return the length of the shortest subarray to remove.

A subarray is a contiguous subsequence of the array.

Constraints:

* 1 <= arr.length <= 10^5
* 0 <= arr[i] <= 10^9

```Python3
from typing import List


class Solution:
    def findLengthOfShortestSubarray(self, arr: List[int]) -> int:
        return -1
```

# Test Case

## `[1, 2, 3, 2, 2, 1, 1, 1] -> 4`

## `[1, 2, 3, 2, 2, 1, 2, 3] -> 4`